### PR TITLE
fixing pipeline

### DIFF
--- a/input/fsh/BackportSubscription.fsh
+++ b/input/fsh/BackportSubscription.fsh
@@ -7,10 +7,10 @@ Description: "Profile on the Subscription resource to enable R5-style topic-base
 * extension contains
     $xverSubTopic named topic 1..1 MS and
     $xverSubFilterBy named filterBy 0..* MS and
-    $xverSubContent named content 0..1 MS and
-    $xverSubHeartbeat named heartbeatPeriod 0..1 and
-    $xverSubTimeout named timeout 0..1 and
-    $xverSubMaxCount named maxCount 0..1 and
+    BackportPayloadContent named content 0..1 MS and
+    BackportHeartbeatPeriod named heartbeatPeriod 0..1 and
+    BackportTimeout named timeout 0..1 and
+    BackportMaxCount named maxCount 0..1 and
     $xverSubIdentifier named identifier 0..* and
     $xverSubName named name 0..1 and
     $xverSubParameter named parameter 0..*
@@ -37,7 +37,7 @@ Description: "Profile on the Subscription resource to enable R5-style topic-base
 * criteria ^short = "Criteria (may be empty for topic-based subscriptions)"
 * criteria ^definition = "When using topic-based subscriptions, the topic is specified via the topic extension. The criteria element is retained for compatibility."
 * channel.payload 1..1
-* channel.type.extension contains $xverSubChannelType named channelType 0..1 MS
+* channel.type.extension contains BackportChannelType named channelType 0..1 MS
 * channel.type.extension[channelType] ^short = "Extended channel type for notifications"
 * channel.type.extension[channelType] ^definition = "The type of channel to send notifications on."
 * channel.type.extension[channelType] ^comment = "This extension allows for the use of additional channel types that were not defined in the FHIR R4 subscription definition."
@@ -163,7 +163,7 @@ Usage: #definition
 * code = #custom-channel
 * base[0] = #Subscription
 * type = #token
-* expression = "Subscription.channel.type.extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-Subscription.channelType').value.ofType(Coding)"
+* expression = "Subscription.channel.type.extension('http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-channel-type').value.ofType(Coding)"
 * xpathUsage = #normal
 
 Instance: Subscription-identifier
@@ -195,5 +195,5 @@ Usage: #definition
 * code = #payload-type
 * base[0] = #Subscription
 * type = #token
-* expression = "Subscription.extension('http://hl7.org/fhir/5.0/StructureDefinition/extension-Subscription.content').value.ofType(code)"
+* expression = "Subscription.extension('http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-payload-content').value.ofType(code)"
 * xpathUsage = #normal

--- a/input/fsh/Common.fsh
+++ b/input/fsh/Common.fsh
@@ -9,14 +9,12 @@ Alias: $authorizationHintExt = http://hl7.org/fhir/uv/subscriptions-backport/Str
 
 Alias: $relatedQueryExt = http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-related-query
 
-// XVer cross-version extension aliases (from hl7.fhir.uv.xver-r5.r4)
+// XVer cross-version extension aliases (from hl7.fhir.uv.xver-r5.r4).
+// NOTE: content / heartbeatPeriod / timeout / maxCount / channelType are NOT
+// provided by xver-r5.r4 0.1.0 — they are defined locally as backport-*
+// extensions in Extensions.fsh and referenced by name in the profile.
 Alias: $xverSubTopic        = http://hl7.org/fhir/5.0/StructureDefinition/extension-Subscription.topic
-Alias: $xverSubChannelType  = http://hl7.org/fhir/5.0/StructureDefinition/extension-Subscription.channelType
 Alias: $xverSubFilterBy     = http://hl7.org/fhir/5.0/StructureDefinition/extension-Subscription.filterBy
-Alias: $xverSubContent      = http://hl7.org/fhir/5.0/StructureDefinition/extension-Subscription.content
-Alias: $xverSubHeartbeat    = http://hl7.org/fhir/5.0/StructureDefinition/extension-Subscription.heartbeatPeriod
-Alias: $xverSubTimeout      = http://hl7.org/fhir/5.0/StructureDefinition/extension-Subscription.timeout
-Alias: $xverSubMaxCount     = http://hl7.org/fhir/5.0/StructureDefinition/extension-Subscription.maxCount
 Alias: $xverSubIdentifier   = http://hl7.org/fhir/5.0/StructureDefinition/extension-Subscription.identifier
 Alias: $xverSubName         = http://hl7.org/fhir/5.0/StructureDefinition/extension-Subscription.name
 Alias: $xverSubParameter    = http://hl7.org/fhir/5.0/StructureDefinition/extension-Subscription.parameter

--- a/input/fsh/Extensions.fsh
+++ b/input/fsh/Extensions.fsh
@@ -18,3 +18,85 @@ Description: "Combination of coded information and query for information related
 * extension[query] ^short = "URL for a query."
 * extension[query] ^definition = "URL used via HTTP GET to perform the query."
 * extension[query].value[x] only string
+
+
+// -----------------------------------------------------------------------------
+// Local backport extensions for R5 Subscription elements that the official
+// cross-version package (hl7.fhir.uv.xver-r5.r4) does NOT provide. As of
+// xver-r5.r4 0.1.0, no cross-version extensions are generated for
+// Subscription.content / .heartbeatPeriod / .timeout / .maxCount (no R4
+// element equivalence in the R5->R4 ConceptMap) nor for .channelType (mapped to
+// the native R4 Subscription.channel.type). These are defined locally here.
+// -----------------------------------------------------------------------------
+
+CodeSystem:  BackportContentCodeSystem
+Id:          backport-content-code-system
+Title:       "Backported R5 Subscription Content Code System"
+Description: "Codes to represent how much resource content to send in the notification payload."
+* insert StructureJurisdiction
+* ^caseSensitive  = true
+* ^experimental   = false
+* #empty         "Empty"         "No resource content is transacted in the notification payload."
+* #id-only       "Id Only"       "Only the resource id is transacted in the notification payload."
+* #full-resource "Full Resource" "The entire resource is transacted in the notification payload."
+
+ValueSet:    BackportContentValueSet
+Id:          backport-content-value-set
+Title:       "Backported R5 Subscription Content Value Set"
+Description: "Codes to represent how much resource content to send in the notification payload."
+* insert StructureJurisdiction
+* ^experimental   = false
+* codes from system BackportContentCodeSystem
+
+Extension:   BackportPayloadContent
+Id:          backport-payload-content
+Title:       "Backported R5 Subscription Payload Content"
+Description: "How much of the resource content to deliver in the notification payload. The choices are an empty payload, only the resource id, or the full resource content."
+* insert StructureJurisdiction
+* insert ExtensionContext(Subscription)
+* value[x] only code
+* valueCode from BackportContentValueSet (required)
+* value[x] ^short      = "Notification content level"
+* value[x] ^definition = "How much of the resource content to deliver in the notification payload. The choices are an empty payload, only the resource id, or the full resource content."
+* value[x] ^comment    = "Sending the payload has obvious security implications. The server is responsible for ensuring that the content is appropriately secured."
+
+Extension:   BackportHeartbeatPeriod
+Id:          backport-heartbeat-period
+Title:       "Backported R5 Subscription Heartbeat Period"
+Description: "Interval in seconds to send 'heartbeat' notifications."
+* insert StructureJurisdiction
+* insert ExtensionContext(Subscription)
+* value[x] only unsignedInt
+* value[x] ^short      = "Interval in seconds to send 'heartbeat' notification"
+* value[x] ^definition = "If present, a 'heartbeat' notification (keepalive) is sent via this channel with an interval period equal to this element's integer value in seconds. If not present, a heartbeat notification is not sent."
+
+Extension:   BackportTimeout
+Id:          backport-timeout
+Title:       "Backported R5 Subscription Timeout"
+Description: "Timeout in seconds to attempt notification delivery."
+* insert StructureJurisdiction
+* insert ExtensionContext(Subscription)
+* value[x] only unsignedInt
+* value[x] ^short      = "Timeout in seconds to attempt notification delivery"
+* value[x] ^definition = "If present, the maximum amount of time a server will allow before failing a notification attempt."
+
+Extension:   BackportMaxCount
+Id:          backport-max-count
+Title:       "Backported R5 Subscription MaxCount"
+Description: "Maximum number of triggering resources included in notification bundles."
+* insert StructureJurisdiction
+* insert ExtensionContext(Subscription)
+* value[x] only positiveInt
+* value[x] ^short      = "Maximum number of triggering resources included in notification bundles"
+* value[x] ^definition = "If present, the maximum number of triggering resources that will be included in a notification bundle. Note that this is not a strict limit on the number of entries in a bundle, as dependent resources can be included."
+
+Extension:   BackportChannelType
+Id:          backport-channel-type
+Title:       "Backported R5 Subscription Additional Channel Type"
+Description: "Additional channel types not defined before FHIR R5."
+* insert StructureJurisdiction
+* insert ExtensionContext(Subscription.channel.type)
+* value[x] only Coding
+* value[x] ^short      = "Extended channel type for notifications"
+* value[x] ^definition = "The type of channel to send notifications on."
+* value[x] ^comment    = "This extension allows for the use of additional channel types that were not defined in the FHIR R4 subscription definition."

--- a/input/pagecontent/channels.md
+++ b/input/pagecontent/channels.md
@@ -92,7 +92,7 @@ An example workflow for receiving notifications via websockets is shown below:
 Notes:
 
 * Notifications sent from the server SHALL be in the MIME Type specified by the [Subscription.channel.payload](http://hl7.org/fhir/subscription-definitions.html#Subscription.channel.payload), however, if notifications are requested for multiple subscriptions with different MIME types, the server MAY choose to send all notifications in a single MIME type.
-* Notifications SHALL conform to the content level specified by the `http://hl7.org/fhir/5.0/StructureDefinition/extension-Subscription.content` extension.
+* Notifications SHALL conform to the content level specified by the `http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-payload-content` extension.
 * When receiving notifications, a connected websocket client has no responsibilities beyond reading the message (e.g., there is no acknowledgement message).
 
 ##### Security Notes

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -84,9 +84,8 @@ jurisdiction: http://unstats.un.org/unsd/methods/m49/m49.htm#001 "World"
 # use cases, the value can be an object with keys for id, uri, and version.
 #
 dependencies:
-  #hl7.fhir.extensions.r5: 4.3.0
-  hl7.fhir.extensions.r5: 4.0.1
-  #hl7.fhir.uv.extensions.r5: 1.0.0
+  # Deprecated old-style cross-version package removed; the official xver
+  # packages below replace it (hl7.fhir.uv.xver-r5.r4 / -r4b.r4).
   hl7.fhir.uv.extensions.r4: 1.0.0
   hl7.fhir.uv.tools.r4: current
   hl7.fhir.uv.xver-r5.r4: 0.1.0


### PR DESCRIPTION
This pull request updates the way R5 Subscription elements are backported to FHIR R4 by introducing locally-defined extensions for several fields that are not provided by the official cross-version package. It also updates references throughout the codebase to use these new backport extensions, adds the necessary code systems and value sets, and clarifies documentation and dependencies accordingly.

**Introduction of local backport extensions:**

* Added new local extensions in `Extensions.fsh` for `BackportPayloadContent`, `BackportHeartbeatPeriod`, `BackportTimeout`, `BackportMaxCount`, and `BackportChannelType` to represent R5 Subscription elements not covered by the official cross-version package. These include their definitions, value constraints, and documentation.

**Profile and expression updates to use local extensions:**

* Updated the `BackportSubscription` profile to use the new local extensions (`BackportPayloadContent`, `BackportHeartbeatPeriod`, `BackportTimeout`, `BackportMaxCount`, `BackportChannelType`) instead of the previous cross-version aliases. [[1]](diffhunk://#diff-d26f883a8af223c15a29b93afde031db1fe2f0fbd264899030a08be41e94d71cL10-R13) [[2]](diffhunk://#diff-d26f883a8af223c15a29b93afde031db1fe2f0fbd264899030a08be41e94d71cL40-R40)
* Changed FHIRPath expressions in the profile to reference the new backport extension URLs for payload content and channel type. [[1]](diffhunk://#diff-d26f883a8af223c15a29b93afde031db1fe2f0fbd264899030a08be41e94d71cL166-R166) [[2]](diffhunk://#diff-d26f883a8af223c15a29b93afde031db1fe2f0fbd264899030a08be41e94d71cL198-R198)

**Alias and dependency clarifications:**

* Updated `Common.fsh` to remove aliases for unsupported cross-version extensions and added comments explaining which elements require local definitions.
* Updated `sushi-config.yaml` to remove deprecated cross-version package dependencies and clarify the use of the official xver packages.

**Documentation updates:**

* Updated documentation in `channels.md` to reference the new backport payload content extension URL for notification content level.